### PR TITLE
proxy参数配置错误

### DIFF
--- a/embykeeper/cli.py
+++ b/embykeeper/cli.py
@@ -57,7 +57,7 @@ def prepare_config(config=None):
     proxy = config.get("proxy", None)
     if proxy:
         proxy.setdefault("scheme", "socks5")
-        proxy.setdefault("hostname", "127.0.0.1")
+        proxy.setdefault("host", "127.0.0.1")
         proxy.setdefault("port", "1080")
     return config
 


### PR DESCRIPTION
配置文件为host，cli.py读取hostname